### PR TITLE
Pulse: trigger classifier → Haiku; send only v3.1 email (~$3-4/day saved)

### DIFF
--- a/.github/workflows/pulse-synth.yml
+++ b/.github/workflows/pulse-synth.yml
@@ -197,10 +197,13 @@ jobs:
         working-directory: pulse
         run: python capture_frontpages.py || echo "Screenshots failed — continuing without"
 
-      - name: Run synthesis + send email
+      - name: Run synthesis (store v1 briefing as v3.1 scaffold; no v1 email)
+        # Computes + stores the v1 briefing so v3.1 can reuse its News Themes /
+        # paper / pulse scaffold, but --no-email suppresses the redundant v1
+        # email. We now send only the v3.1 email. (v1 email retired 2026-06-30.)
         if: steps.guard.outputs.should_run == 'true'
         working-directory: pulse/scripts
-        run: python run_pipeline.py synthesize
+        run: python run_pipeline.py synthesize --no-email
 
       # V2 disabled 2026-06-16: user is not using v2 comparison output.
       # Code preserved (v2_runner.py + dependencies untouched) in case we
@@ -223,16 +226,9 @@ jobs:
           PULSE_DB: ${{ github.workspace }}/pulse/data/pulse.db
         run: python v3_1_runner.py --to aziz@home-economics.us || echo "V3.1 run failed — continuing without"
 
-      - name: Send daily pipeline-health diagnostic email (v1)
-        # Stage-by-stage health report covering collection, enrichment,
-        # v1 synthesis, front pages, and v1 delivery. Goes only to aziz@... so
-        # he can spot anything broken in tomorrow's run. Failure here is
-        # informational only — never takes down the v1 send.
-        if: steps.guard.outputs.should_run == 'true'
-        working-directory: pulse/scripts
-        env:
-          PULSE_DB: ${{ github.workspace }}/pulse/data/pulse.db
-        run: python delivery/pipeline_health_report.py --variant v1 --to aziz@home-economics.us || echo "Health report (v1) failed — continuing without"
+      # v1 health-report step retired 2026-06-30 alongside the v1 email. The
+      # v3.1 health report below runs the same upstream collectors/enrichment/
+      # front-pages probes, so v1's was redundant once we stopped sending v1.
 
       - name: Send daily pipeline-health diagnostic email (v3.1)
         # Parallel health report focused on v3.1's hybrid synthesis pipeline:

--- a/pulse/scripts/analysis/trigger_classifier.py
+++ b/pulse/scripts/analysis/trigger_classifier.py
@@ -33,13 +33,16 @@ import anthropic
 logger = logging.getLogger(__name__)
 
 
-# Use Opus per the "quality > cost" directive. The classifier is the gatekeeper;
-# false-rejects are expensive (lost news) and false-accepts are expensive
-# (op-eds in the briefing). Worth the marginal cost over Sonnet.
-# Bumped 4.7 -> 4.8 on 2026-06-03 — Opus 4.8 dropped on May 28 with 3x lower
-# pricing ($5/M input, $25/M output vs 4.7's $15/$75) AND meaningfully better
-# constraint adherence per Anthropic's release notes.
-OPUS_MODEL = "claude-opus-4-8"
+# The classifier is the gatekeeper for the News Themes: false-rejects lose
+# news, false-accepts let op-eds/recap into the briefing.
+# History: ran on Sonnet, then Opus 4.7, then Opus 4.8 (2026-06-03, "quality >
+# cost"). But this runs ~1,700 items/day in ~19 batches, so on Opus it became
+# the single largest line item — it roughly tripled daily Anthropic spend
+# (~$2 -> ~$7/day) when it landed on Opus mid-June. Reverted to Haiku on
+# 2026-06-30 to restore the old cost (~$3-4/day saved). It only feeds v1's
+# News Themes; v3.1's Conversations don't use it. Watch the News Themes
+# quality for a few days — if the gate degrades, step back up to Opus 4.8.
+CLASSIFIER_MODEL = "claude-haiku-4-5-20251001"
 
 # Cache schema/category version. Bump this whenever the trigger-type taxonomy,
 # the system prompt's classification rules, or the cached payload meaning
@@ -246,7 +249,7 @@ def _classify_batch(
     )
     try:
         resp = client.messages.create(
-            model=OPUS_MODEL,
+            model=CLASSIFIER_MODEL,
             max_tokens=8000,
             system=[{
                 "type": "text",
@@ -257,7 +260,7 @@ def _classify_batch(
         )
         try:
             from analysis.anthropic_spend import record_usage as _rec_usage
-            _rec_usage(OPUS_MODEL, resp.usage)
+            _rec_usage(CLASSIFIER_MODEL, resp.usage)
         except Exception:
             pass
     except Exception as e:
@@ -383,7 +386,7 @@ def classify_trigger_types(
     total = len(pending)
     n_batches = (total + batch_size - 1) // batch_size
     logger.info(
-        f"trigger_classifier: classifying {total} item(s) via {OPUS_MODEL} "
+        f"trigger_classifier: classifying {total} item(s) via {CLASSIFIER_MODEL} "
         f"across {n_batches} batch(es) of <={batch_size} "
         f"(prefiltered={prefiltered}, cached={cache_hits})"
     )

--- a/pulse/scripts/run_pipeline.py
+++ b/pulse/scripts/run_pipeline.py
@@ -987,10 +987,15 @@ def cmd_synthesize(args):
         from store import update_briefing_content
         update_briefing_content(conn, briefing["_briefing_id"], briefing)
 
-    # Email
-    logger.info("Phase 5: Email delivery")
-    from delivery.email_briefing import send_email
-    email_sent = send_email(briefing)
+    # Email — skip the send when --no-email (the v1 briefing is already stored
+    # above for v3.1's scaffold; we just don't want the v1 email in the inbox).
+    if getattr(args, "no_email", False):
+        logger.info("Phase 5: Email delivery SKIPPED (--no-email); briefing stored for v3.1 scaffold")
+        email_sent = False
+    else:
+        logger.info("Phase 5: Email delivery")
+        from delivery.email_briefing import send_email
+        email_sent = send_email(briefing)
 
     if email_sent and "_briefing_id" in briefing:
         mark_briefing_emailed(conn, briefing["_briefing_id"])
@@ -1118,6 +1123,12 @@ def main():
             sub.add_argument(
                 "--sources", nargs="*",
                 help="Specific sources to collect from (default: all)"
+            )
+        if name == "synthesize":
+            sub.add_argument(
+                "--no-email", action="store_true",
+                help="Compute + store the v1 briefing (v3.1 reuses it as its "
+                     "scaffold) but don't send the v1 email.",
             )
 
     parser.add_argument("--verbose", "-v", action="store_true", help="Debug logging")


### PR DESCRIPTION
## What & why
Daily Anthropic spend jumped from ~\$2/day to ~\$7/day in mid-June. Investigation against the `anthropic_spend` table showed the cause was **not** the second (v3.1) email — it was the **trigger classifier being switched onto Opus-4.8**, where it runs ~1,700 items/day in ~19 batches (the single largest line item). It only feeds v1's News Themes.

## Changes
- **`trigger_classifier.py`** — `OPUS_MODEL` → `CLASSIFIER_MODEL = claude-haiku-4-5` (renamed so the constant isn't misleading). Recovers ~\$3-4/day. `CLASSIFIER_VERSION` left at `v2` so existing Opus-labelled items stay cached; only new items reclassify on Haiku.
- **`run_pipeline.py`** — new `synthesize --no-email` flag: still computes + stores the v1 briefing (v3.1's scaffold), just doesn't send the v1 email.
- **`pulse-synth.yml`** — synthesis step uses `--no-email`; v1 health-report step removed (v3.1's covers the same upstream probes).

## Effect
- **v3.1 email unchanged** — same corpus/clustering/roundups. News Themes come from v1 synthesis, which still runs. (Only possible ripple: a marginal roundup near a News-Theme boundary, via the dedup list, and only if Haiku shifts a theme.)
- You stop receiving the v1 email + v1 health report.
- **Watch News Themes quality for a few days** — that's the one place Haiku classification could soften. Revert path is documented in the file comment (set `CLASSIFIER_MODEL` back to `claude-opus-4-8`).

## Validation
- `py_compile` clean; workflow YAML parses; `--no-email` parses.
- Live smoke test: ran the classifier on synthetic items → correct labels (official_data / commentary / opinion-rejected) via `claude-haiku-4-5`, HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)